### PR TITLE
Catkin volumeを永続化する処理を追加

### DIFF
--- a/ros-nu20-novnc/Dockerfile
+++ b/ros-nu20-novnc/Dockerfile
@@ -77,6 +77,8 @@ RUN sudo chmod +x ~/setup_robot_programming/entrypoint.sh
 #ENV DISPLAY host.docker.internal:0.0
 
 RUN sudo apt-get install -y rsync
+WORKDIR /home/ubuntu
+
 #ENTRYPOINT [ "/home/ubuntu/setup_robot_programming/entrypoint.sh" ]
 
 #Reference

--- a/ros-nu20-novnc/Dockerfile
+++ b/ros-nu20-novnc/Dockerfile
@@ -11,18 +11,18 @@ RUN sed -i 's@archive.ubuntu.com@ftp.jaist.ac.jp/pub/Linux@g' /etc/apt/sources.l
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd --create-home --home-dir /home/ubuntu --shell /bin/bash --user-group --groups adm,sudo ubuntu && \
+RUN locale-gen ja_JP.UTF-8 && useradd --create-home --home-dir /home/ubuntu --shell /bin/bash --user-group --groups adm,sudo ubuntu && \
     echo ubuntu:ubuntu | chpasswd && \
     echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 USER ubuntu
+RUN sudo apt update
+RUN sudo apt-get install -y iputils-ping net-tools x11-apps
 
 WORKDIR /home/ubuntu/setup_robot_programming
 
 #Basic Package
 RUN sudo apt-get update -y && sudo apt-get upgrade -y
 RUN sudo apt-get install -y --no-install-recommends curl python3-pip python3-setuptools zip unzip
-RUN sudo apt-get install -y iputils-ping net-tools x11-apps 
-# Unable to locate package python-pip 
 #sudo apt-get install -y --no-install-recommends openssh-server x11-xserver-utils dbus-x11
 
 #Python Packages
@@ -60,15 +60,24 @@ RUN sudo apt-get -y clean \
     && sudo rm -rf /var/lib/apt/lists/*
 
 #init ws
-COPY ./init_workspace.sh /home/ubuntu/setup_robot_programming/init_workspace.sh
-RUN sudo chmod +x ~/setup_robot_programming/init_workspace.sh && bash ~/setup_robot_programming/init_workspace.sh
+#COPY ./init_workspace.sh /home/ubuntu/setup_robot_programming/init_workspace.sh
+#RUN sudo chmod +x ~/setup_robot_programming/init_workspace.sh && bash ~/setup_robot_programming/init_workspace.sh
 
 COPY ./install_sigverse.sh /home/ubuntu/setup_robot_programming/install_sigverse.sh
 RUN sudo chmod +x ~/setup_robot_programming/install_sigverse.sh && bash ~/setup_robot_programming/install_sigverse.sh
 
+RUN sudo chown -R ubuntu:ubuntu /home/ubuntu/setup_robot_programming
+RUN git clone https://github.com/SIGVerse/sigverse_ros_package.git
+
+COPY ./entrypoint.sh /home/ubuntu/setup_robot_programming/entrypoint.sh
+RUN sudo chmod +x ~/setup_robot_programming/entrypoint.sh
+
 #ENV LANG ja_JP.UTF-8
 #ENV LIBGL_ALWAYS_INDIRECT=0
 #ENV DISPLAY host.docker.internal:0.0
+
+RUN sudo apt-get install -y rsync
+#ENTRYPOINT [ "/home/ubuntu/setup_robot_programming/entrypoint.sh" ]
 
 #Reference
 # Timezone https://qiita.com/rururu_kenken/items/972314402d588e073d40

--- a/ros-nu20-novnc/Dockerfile
+++ b/ros-nu20-novnc/Dockerfile
@@ -11,23 +11,19 @@ RUN sed -i 's@archive.ubuntu.com@ftp.jaist.ac.jp/pub/Linux@g' /etc/apt/sources.l
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN locale-gen ja_JP.UTF-8 && useradd --create-home --home-dir /home/ubuntu --shell /bin/bash --user-group --groups adm,sudo ubuntu && \
+RUN useradd --create-home --home-dir /home/ubuntu --shell /bin/bash --user-group --groups adm,sudo ubuntu && \
     echo ubuntu:ubuntu | chpasswd && \
     echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 USER ubuntu
-RUN sudo apt update
-RUN sudo apt-get install -y iputils-ping net-tools x11-apps
-
-#RUN git clone https://github.com/KMiyawaki/setup_robot_programming.git /home/ubuntu/setup_robot_programming
 
 WORKDIR /home/ubuntu/setup_robot_programming
 
 #Basic Package
 RUN sudo apt-get update -y && sudo apt-get upgrade -y
 RUN sudo apt-get install -y --no-install-recommends curl python3-pip python3-setuptools zip unzip
+RUN sudo apt-get install -y iputils-ping net-tools x11-apps 
 # Unable to locate package python-pip 
-#sudo apt-get install -y --no-install-recommends openssh-server
-#sudo apt-get install -y --no-install-recommends x11-apps x11-utils x11-xserver-utils dbus-x11
+#sudo apt-get install -y --no-install-recommends openssh-server x11-xserver-utils dbus-x11
 
 #Python Packages
 RUN sudo apt-get install -y --no-install-recommends python-tk
@@ -70,14 +66,11 @@ RUN sudo chmod +x ~/setup_robot_programming/init_workspace.sh && bash ~/setup_ro
 COPY ./install_sigverse.sh /home/ubuntu/setup_robot_programming/install_sigverse.sh
 RUN sudo chmod +x ~/setup_robot_programming/install_sigverse.sh && bash ~/setup_robot_programming/install_sigverse.sh
 
-#RUN ./install_basic_packages.sh \
-#    && ./install_python_packages.sh \
-#    && ./install_ros_packages.sh \
-#    && ./install_vscode_extensions_from_file.sh \
-#    && ./upgrade_packages.sh \
-#    && ./init_workspace.sh  \
-#    && 
-ENV LANG ja_JP.UTF-8
-ENV LIBGL_ALWAYS_INDIRECT=0
-ENV DISPLAY host.docker.internal:0.0
+#ENV LANG ja_JP.UTF-8
+#ENV LIBGL_ALWAYS_INDIRECT=0
+#ENV DISPLAY host.docker.internal:0.0
 
+#Reference
+# Timezone https://qiita.com/rururu_kenken/items/972314402d588e073d40
+# https://github.com/KMiyawaki/setup_robot_programming
+# OpenGL https://b.ueda.tech/?post=20190802

--- a/ros-nu20-novnc/Readme.md
+++ b/ros-nu20-novnc/Readme.md
@@ -1,9 +1,11 @@
 - ros:melodicからsigverseまでセットアップしたDockerfileを利用している
 - ros-nu20コンテナ
   - roscoreを実行するコンテナ
+  - ~/catkin_ws がある
 - rvizコンテナ
-  - rvizを実行するコンテナ．中身はros-nu20と同じ
-- guiコンテナ
+  - rvizを実行するコンテナ．中身はros-nu20とほぼ同じ
+  - ~/catkin_ws はない
+- novncコンテナ
   - rvizを実行した画面をnovncに流して表示するコンテナ
 
 ### 実行方法

--- a/ros-nu20-novnc/Readme.md
+++ b/ros-nu20-novnc/Readme.md
@@ -22,7 +22,8 @@ $ docker-compose down
 - `docker-compose up -d` をホストで実行した後，http://localhost:8080/vnc.html?resize=scale&autoconnect=true にブラウザでアクセスする
 - rvizコンテナ（rvizコマンド実行するだけ）で実行されているrvizの画面が表示される
 
-### ToDo
+### Done
+- ~/catkin_ws を永続化し，初期化するように修正してみた
 - `install_sigverse.sh` の `catkin_make`コマンドだけDockerfile内で実行できなかった（Not foundになる）ので，ログイン後手動で実行する必要あり．
   - ↓を追加したらいけたヽ(^o^)丿
 ```sh
@@ -31,6 +32,8 @@ echo "**Making workspace. Target ros-${TARGET_ROS}**"
 ROS_SETUP="/opt/ros/${TARGET_ROS}/setup.bash"
 source ${ROS_SETUP}
 ```
+
+### ToDo
 - ノードを追加したかったらどうすればよいか
   - ros-nu20に下記のコマンドでアクセスしてノードを実装してコマンド実行したらrvizの画面に反映されるかどうか
   - `docker exec -it ros-nu20 bash`

--- a/ros-nu20-novnc/Readme.md
+++ b/ros-nu20-novnc/Readme.md
@@ -24,6 +24,7 @@ $ docker-compose down
 
 ### Done
 - ~/catkin_ws を永続化し，初期化するように修正してみた
+  - ボリュームの中身を一度全部消したい場合は `docker-compose down --rmi local --volumes --remove-orphans` このあたりでvolume削除すればOK
 - `install_sigverse.sh` の `catkin_make`コマンドだけDockerfile内で実行できなかった（Not foundになる）ので，ログイン後手動で実行する必要あり．
   - ↓を追加したらいけたヽ(^o^)丿
 ```sh

--- a/ros-nu20-novnc/docker-compose.yml
+++ b/ros-nu20-novnc/docker-compose.yml
@@ -4,34 +4,36 @@ services:
     restart: always
     container_name: ros-nu20
     build: .
-    working_dir: "/work"
     volumes:
-      - ./:/work
+      - catkin_ws:/catkin_ws
     ports:
       - "11311:11311"
     depends_on:
-      - gui
+      - novnc
     command:
+      - /home/ubuntu/setup_robot_programming/entrypoint.sh
       - roscore
 
-  ros-nu20-2:
+  rviz:
     restart: always
     container_name: rviz
     build: .
-    working_dir: "/work"
     volumes:
-      - ./:/work
+      - catkin_ws:/catkin_ws
     environment:
       - ROS_HOSTNAME=rviz
       - ROS_MASTER_URI=http://ros-nu20:11311
-      - DISPLAY=gui:0.0
+      - DISPLAY=novnc:0.0
     depends_on:
       - ros-nu20
-      - gui
+      - novnc
     command:
       - rviz
 
-  gui:
+  novnc:
     image: gramaziokohler/novnc:latest
     ports:
       - "8080:8080"
+
+volumes:
+  catkin_ws:

--- a/ros-nu20-novnc/entrypoint.sh
+++ b/ros-nu20-novnc/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+sudo chown -R ubuntu:ubuntu /catkin_ws
+
+#ln -sfn /home/developer/.vscode /workspace/.vscode
+
+ln -sfn /catkin_ws /home/ubuntu/catkin_ws
+
+# init workspace
+TARGET_ROS="noetic"
+echo "**Making workspace. Target ros-${TARGET_ROS}**"
+ROS_SETUP="/opt/ros/${TARGET_ROS}/setup.bash"
+echo "source ${ROS_SETUP}" >> ~/.bashrc
+
+source /opt/ros/${TARGET_ROS}/setup.bash
+
+mkdir -p /catkin_ws/src && cd /catkin_ws/src && catkin_init_workspace || true
+
+cd /home/ubuntu/setup_robot_programming/sigverse_ros_package && git pull origin master && rsync -av  /home/ubuntu/setup_robot_programming/sigverse_ros_package/ /home/ubuntu/catkin_ws/src/sigverse_ros_package/ && cd /home/ubuntu/catkin_ws/ && catkin_make
+
+WS_SETUP="/catkin_ws/devel/setup.bash"
+echo "source ~${WS_SETUP}" >> ~/.bashrc
+
+exec "$@"
+#rviz &

--- a/ros-nu20-novnc/install_sigverse.sh
+++ b/ros-nu20-novnc/install_sigverse.sh
@@ -24,7 +24,7 @@ sudo make EP_mnmlstc_core
 make
 sudo make install
 
-cd ~/catkin_ws/src
-git clone https://github.com/SIGVerse/sigverse_ros_package.git
-cd ..
-catkin_make
+#cd ~/catkin_ws/src
+#git clone https://github.com/SIGVerse/sigverse_ros_package.git
+#cd ..
+#catkin_make


### PR DESCRIPTION
/catkin_ws を作成し，永続化した．
ros-nu20を起動するときにentrypoint.sh 内で /catkin_ws を ~/catkin_ws にln -sfn している
同時にsigverse_ros_packageも展開している